### PR TITLE
Upgrade sample to use lock@10.2

### DIFF
--- a/00-Starter-Seed/app.js
+++ b/00-Starter-Seed/app.js
@@ -61,17 +61,25 @@ var App = Vue.extend({
       var self = this;
       var lock = new Auth0Lock(AUTH0_CLIENT_ID, AUTH0_DOMAIN);
 
-      lock.show((err, profile, token) => {
-        if(err) {
-          // Handle the error
-          console.log(err)
-        } else {
+      lock.on('authenticated', (authResult) => {
+        lock.getProfile(authResult.idToken, (error, profile) => {
+          if (error) {
+            // Handle error
+            return;
+          }
           // Set the token and user profile in local storage
           localStorage.setItem('profile', JSON.stringify(profile));
-          localStorage.setItem('id_token', token);
+          localStorage.setItem('id_token', authResult.idToken);
+
           self.authenticated = true;
-        }
+        });
       });
+
+      lock.on('authorizaton_error', (error) {
+        // handle error when authorizaton fails
+      });
+
+      lock.show();
     },
     logout() {
       var self = this;

--- a/00-Starter-Seed/index.html
+++ b/00-Starter-Seed/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Auth0 Vue.js Example</title>
     <!-- Auth0 Lock script -->
-    <script src="//cdn.auth0.com/js/lock-9.0.min.js"></script>
+    <script src="//cdn.auth0.com/js/lock/10.2/lock.min.js"></script>
     <script src="auth0-variables.js"></script>
     <!-- Setting the right viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />


### PR DESCRIPTION
Related to https://github.com/auth0/lock/issues/579

Downloaded sample from https://auth0.com/docs/quickstart/spa/vuejs was set up for **Lock v9**, while all docs in that quickstart explained how to use **Lock v10**.
