### PR TITLE
Fix ID to match Auth0Lock(AUTH_CONFIG.clientId)

### DIFF
--- a/05-Authorization/src/auth/auth0-variables.js.example
+++ b/05-Authorization/src/auth/auth0-variables.js.example
@@ -1,5 +1,5 @@
 export const AUTH_CONFIG = {
-  clientID: '{CLIENT_ID}',
+  clientId: '{CLIENT_ID}',
   domain: '{DOMAIN}',
   callbackURL: 'http://localhost:8080',
   apiUrl: '{API_IDENTIFIER}'


### PR DESCRIPTION
Example AUTH_CONFIG does not use camelCase (https://github.com/auth0-samples/auth0-vue-samples/blob/master/05-Authorization/src/auth/auth0-variables.js.example) ID, whereas function call does (https://github.com/auth0-samples/auth0-vue-samples/blob/master/05-Authorization/src/auth/AuthService.js#L29), which could result in an error for someone who is cloning or copying and pasting the code: 

```
Uncaught Error: A `clientID` string must be provided as first argument.
```

Changing property name from `clientID` to `clientId` relegates this possibility. PR submitted with this intent.