### PR TITLE
Using eventemitter3 instead of EventEmitter

### DIFF
--- a/01-Login/package.json
+++ b/01-Login/package.json
@@ -14,11 +14,11 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "EventEmitter": "^1.0.0",
     "auth0-js": "^8.8.0",
     "bootstrap": "^3.3.7",
     "eslint-plugin-import": "^2.6.1",
     "eslint-plugin-node": "^5.1.0",
+    "eventemitter3": "^2.0.3",
     "vue": "^2.3.4",
     "vue-resource": "^1.3.4",
     "vue-router": "^2.7.0"

--- a/01-Login/src/auth/AuthService.js
+++ b/01-Login/src/auth/AuthService.js
@@ -1,6 +1,6 @@
 import auth0 from 'auth0-js'
 import { AUTH_CONFIG } from './auth0-variables'
-import EventEmitter from 'EventEmitter'
+import EventEmitter from 'eventemitter3'
 import router from './../router'
 
 export default class AuthService {

--- a/05-Authorization/package.json
+++ b/05-Authorization/package.json
@@ -15,13 +15,13 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "EventEmitter": "^1.0.0",
     "auth0-lock": "^10.18.0",
     "bootstrap": "^3.3.7",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
     "eslint-plugin-import": "^2.6.1",
     "eslint-plugin-node": "^5.1.0",
+    "eventemitter3": "^2.0.3",
     "express-jwt": "^5.3.0",
     "express-jwt-authz": "^1.0.0",
     "jwks-rsa": "^1.2.0",

--- a/05-Authorization/src/auth/AuthService.js
+++ b/05-Authorization/src/auth/AuthService.js
@@ -1,6 +1,6 @@
 import Auth0Lock from 'auth0-lock'
 import { AUTH_CONFIG } from './auth0-variables'
-import EventEmitter from 'EventEmitter'
+import EventEmitter from 'eventemitter3'
 import decode from 'jwt-decode'
 import Router from 'vue-router'
 


### PR DESCRIPTION
Using eventemitter3 instead of EventEmitter to avoid build problems with UglifyJS.
npn run build is failing in Uglify EventEmitter.js as it contains ES6 code.