### PR TITLE
Ensure query string is kept when redirecting through auth login

### DIFF
--- a/01-Login/src/router.js
+++ b/01-Login/src/router.js
@@ -34,7 +34,7 @@ router.beforeEach((to, from, next) => {
     return next();
   }
 
-  auth.login({ target: to.path });
+  auth.login({ target: to.fullPath });
 });
 
 export default router;


### PR DESCRIPTION
Prior to this change query information is lost when going through an auth login. For example if the router `beforeEach` is called on a link sent to a user like: `https://mysite.com/a_page?foo=bar`

```
to.path => '/a_page'
to.fullPath => /a_page?foo=bar'
```

So this ensures that query information is passed along in the `target` to get the user back to where they were headed.