### PR TITLE
Fixes to the Error.vue component and popup mode

### DIFF
--- a/01-Login/src/auth/authWrapper.js
+++ b/01-Login/src/auth/authWrapper.js
@@ -32,6 +32,8 @@ export const useAuth0 = ({
 
         try {
           await this.auth0Client.loginWithPopup(o);
+          this.user = await this.auth0Client.getUser();
+          this.isAuthenticated = await this.auth0Client.isAuthenticated();
           this.error = null;
         } catch (e) {
           console.error(e);
@@ -39,9 +41,6 @@ export const useAuth0 = ({
         } finally {
           this.popupOpen = false;
         }
-
-        this.user = await this.auth0Client.getUser();
-        this.isAuthenticated = true;
       },
       async handleRedirectCallback() {
         this.loading = true;

--- a/01-Login/src/auth/authWrapper.js
+++ b/01-Login/src/auth/authWrapper.js
@@ -32,8 +32,10 @@ export const useAuth0 = ({
 
         try {
           await this.auth0Client.loginWithPopup(o);
+          this.error = null;
         } catch (e) {
           console.error(e);
+          this.error = e;
         } finally {
           this.popupOpen = false;
         }
@@ -47,6 +49,7 @@ export const useAuth0 = ({
           await this.auth0Client.handleRedirectCallback();
           this.user = await this.auth0Client.getUser();
           this.isAuthenticated = true;
+          this.error = null;
         } catch (e) {
           this.error = e;
         } finally {
@@ -83,6 +86,7 @@ export const useAuth0 = ({
           window.location.search.includes("state=")
         ) {
           const { appState } = await this.auth0Client.handleRedirectCallback();
+          this.error = null;
           onRedirectCallback(appState);
         }
       } catch (e) {

--- a/01-Login/src/components/Error.vue
+++ b/01-Login/src/components/Error.vue
@@ -10,14 +10,12 @@
 <script>
 export default {
   name: "Error",
-  methods: {
-    msg() {
-      return this.$auth.error;
-    }
-  },
   computed: {
     show() {
       return this.$auth.error !== null;
+    },
+    msg() {
+      return this.$auth.error;
     }
   }
 };

--- a/01-Login/src/components/Error.vue
+++ b/01-Login/src/components/Error.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="alert alert-danger alert-dismissible" v-if="show">
+  <div class="alert alert-danger alert-dismissible" v-if="msg">
     {{msg}}
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
@@ -11,9 +11,6 @@
 export default {
   name: "Error",
   computed: {
-    show() {
-      return this.$auth.error !== null;
-    },
     msg() {
       return this.$auth.error;
     }

--- a/02-Calling-an-API/src/auth/authWrapper.js
+++ b/02-Calling-an-API/src/auth/authWrapper.js
@@ -32,6 +32,8 @@ export const useAuth0 = ({
 
         try {
           await this.auth0Client.loginWithPopup(o);
+          this.user = await this.auth0Client.getUser();
+          this.isAuthenticated = await this.auth0Client.isAuthenticated();
           this.error = null;
         } catch (e) {
           console.error(e);
@@ -39,9 +41,6 @@ export const useAuth0 = ({
         } finally {
           this.popupOpen = false;
         }
-
-        this.user = await this.auth0Client.getUser();
-        this.isAuthenticated = true;
       },
       async handleRedirectCallback() {
         this.loading = true;

--- a/02-Calling-an-API/src/auth/authWrapper.js
+++ b/02-Calling-an-API/src/auth/authWrapper.js
@@ -10,7 +10,7 @@ export const getInstance = () => instance;
 
 export const useAuth0 = ({
   onRedirectCallback = DEFAULT_REDIRECT_CALLBACK,
-  redirect_uri = window.location.origin,
+  redirectUri = window.location.origin,
   ...options
 }) => {
   if (instance) return instance;
@@ -32,8 +32,10 @@ export const useAuth0 = ({
 
         try {
           await this.auth0Client.loginWithPopup(o);
+          this.error = null;
         } catch (e) {
           console.error(e);
+          this.error = e;
         } finally {
           this.popupOpen = false;
         }
@@ -47,6 +49,7 @@ export const useAuth0 = ({
           await this.auth0Client.handleRedirectCallback();
           this.user = await this.auth0Client.getUser();
           this.isAuthenticated = true;
+          this.error = null;
         } catch (e) {
           this.error = e;
         } finally {
@@ -74,7 +77,7 @@ export const useAuth0 = ({
         domain: options.domain,
         client_id: options.clientId,
         audience: options.audience,
-        redirect_uri
+        redirect_uri: redirectUri
       });
 
       try {
@@ -83,6 +86,7 @@ export const useAuth0 = ({
           window.location.search.includes("state=")
         ) {
           const { appState } = await this.auth0Client.handleRedirectCallback();
+          this.error = null;
           onRedirectCallback(appState);
         }
       } catch (e) {

--- a/02-Calling-an-API/src/components/Error.vue
+++ b/02-Calling-an-API/src/components/Error.vue
@@ -10,14 +10,12 @@
 <script>
 export default {
   name: "Error",
-  methods: {
-    msg() {
-      return this.$auth.error;
-    }
-  },
   computed: {
     show() {
       return this.$auth.error !== null;
+    },
+    msg() {
+      return this.$auth.error;
     }
   }
 };

--- a/02-Calling-an-API/src/components/Error.vue
+++ b/02-Calling-an-API/src/components/Error.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="alert alert-danger alert-dismissible" v-if="show">
+  <div class="alert alert-danger alert-dismissible" v-if="msg">
     {{msg}}
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
@@ -11,9 +11,6 @@
 export default {
   name: "Error",
   computed: {
-    show() {
-      return this.$auth.error !== null;
-    },
     msg() {
       return this.$auth.error;
     }


### PR DESCRIPTION
This PR fixes #89 and the `Error.vue` component, where the `msg` method is now a computed property, and the `show` prop is removed altogether.

It also takes care to make sure that the `error` prop is set correctly when using the SDK in popup mode for authentication. As part of investigating that, I discovered that the `user` and `isAuthenticated` props were not being set correctly when using popup mode, which has now been rectified in this PR.