### PR TITLE
Changes for consistency between samples

### DIFF
--- a/02-Calling-an-API/README.md
+++ b/02-Calling-an-API/README.md
@@ -27,7 +27,7 @@ To do this, first copy `auth_config.sample.json` into a new file in the same fol
 This compiles and serves the Vue app, and starts the backend API server on port 3001:
 
 ```bash
-npm run dev
+npm run serve
 ```
 
 ## Deployment

--- a/02-Calling-an-API/package.json
+++ b/02-Calling-an-API/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve-vue": "vue-cli-service serve",
+    "serve": "npm-run-all --parallel serve-vue backend-dev",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "dev": "npm-run-all --parallel serve backend-dev",

--- a/02-Calling-an-API/package.json
+++ b/02-Calling-an-API/package.json
@@ -7,7 +7,6 @@
     "serve": "npm-run-all --parallel serve-vue backend-dev",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "dev": "npm-run-all --parallel serve backend-dev",
     "backend-dev": "nodemon bin/www"
   },
   "dependencies": {


### PR DESCRIPTION
Modifying the 'serve' command to also run the backend. This way, it is consistent with what is shown on the sample download instructions.