### PR TITLE
[QS-437] Update router location

### DIFF
--- a/01-Login/src/router/index.js
+++ b/01-Login/src/router/index.js
@@ -1,8 +1,8 @@
 import Vue from "vue";
 import Router from "vue-router";
-import Home from "./views/Home.vue";
-import Profile from "./views/Profile.vue";
-import { authGuard } from "./auth";
+import Home from "../views/Home.vue";
+import Profile from "../views/Profile.vue";
+import { authGuard } from "../auth";
 
 Vue.use(Router);
 

--- a/02-Calling-an-API/src/router/index.js
+++ b/02-Calling-an-API/src/router/index.js
@@ -1,9 +1,9 @@
 import Vue from "vue";
 import Router from "vue-router";
-import Home from "./views/Home.vue";
-import Profile from "./views/Profile.vue";
-import ExternalApi from "./views/ExternalApi.vue";
-import { authGuard } from "./auth";
+import Home from "../views/Home.vue";
+import Profile from "../views/Profile.vue";
+import ExternalApi from "../views/ExternalApi.vue";
+import { authGuard } from "../auth";
 
 Vue.use(Router);
 


### PR DESCRIPTION
Since `@vue/cli` 4, the command `vue add router` places the router code in `src/router/index.js` (was previously `src/router.js`).

Update the sample applications to reflect this.