### PR TITLE
getTokenSilently now updates user property

### DIFF
--- a/01-Login/src/auth/authWrapper.js
+++ b/01-Login/src/auth/authWrapper.js
@@ -61,8 +61,10 @@ export const useAuth0 = ({
       getIdTokenClaims(o) {
         return this.auth0Client.getIdTokenClaims(o);
       },
-      getTokenSilently(o) {
-        return this.auth0Client.getTokenSilently(o);
+      async getTokenSilently(o) {
+        const token = await this.auth0Client.getTokenSilently(o);
+        this.user = await this.auth0Client.getUser();
+        return token;
       },
       getTokenWithPopup(o) {
         return this.auth0Client.getTokenWithPopup(o);
@@ -90,8 +92,8 @@ export const useAuth0 = ({
       } catch (e) {
         this.error = e;
       } finally {
-        this.isAuthenticated = await this.auth0Client.isAuthenticated();
         this.user = await this.auth0Client.getUser();
+        this.isAuthenticated = await this.auth0Client.isAuthenticated();
         this.loading = false;
       }
     }

--- a/02-Calling-an-API/src/auth/authWrapper.js
+++ b/02-Calling-an-API/src/auth/authWrapper.js
@@ -61,8 +61,10 @@ export const useAuth0 = ({
       getIdTokenClaims(o) {
         return this.auth0Client.getIdTokenClaims(o);
       },
-      getTokenSilently(o) {
-        return this.auth0Client.getTokenSilently(o);
+      async getTokenSilently(o) {
+        const token = await this.auth0Client.getTokenSilently(o);
+        this.user = await this.auth0Client.getUser();
+        return token;
       },
       getTokenWithPopup(o) {
         return this.auth0Client.getTokenWithPopup(o);
@@ -90,8 +92,8 @@ export const useAuth0 = ({
       } catch (e) {
         this.error = e;
       } finally {
-        this.isAuthenticated = await this.auth0Client.isAuthenticated();
         this.user = await this.auth0Client.getUser();
+        this.isAuthenticated = await this.auth0Client.isAuthenticated();
         this.loading = false;
       }
     }


### PR DESCRIPTION
This fixes two issues I have caught recently:

#154 - I was using the getTokenSilently to update my token after an API call that changed the user permissions. This change makes the Vue component update the user property as part of that call.

new issue - I encountered a race condition where my Vue components were reacting to `isAuthenticated` being set but the `user` property was not yet set. So by changing the order the properties are set, the `user` property is always set before `isAuthenticated`.

Let me know if you have any questions!