### PR TITLE
Configure proxy when calling an API

### DIFF
--- a/02-Calling-an-API/vite.config.js
+++ b/02-Calling-an-API/vite.config.js
@@ -3,5 +3,10 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    }
+  },
   plugins: [vue()]
 })


### PR DESCRIPTION
We should configure a Proxy when running the sample to Call an API, else the API call does not work.