### PR TITLE
fix: include audience in authorizationParams

### DIFF
--- a/01-Login/auth_config.json.example
+++ b/01-Login/auth_config.json.example
@@ -1,4 +1,7 @@
 {
   "domain": "{DOMAIN}",
-  "clientId": "{CLIENT_ID}"
+  "clientId": "{CLIENT_ID}",
+  "authorizationParams": {
+    "audience": "{API_IDENTIFIER}"
+  }
 }

--- a/01-Login/src/main.ts
+++ b/01-Login/src/main.ts
@@ -26,6 +26,7 @@ app
       clientId: authConfig.clientId,
       authorizationParams: {
         redirect_uri: window.location.origin,
+        audience: authConfig.authorizationParams.audience,
       }
     })
   )

--- a/01-Login/src/views/Profile.vue
+++ b/01-Login/src/views/Profile.vue
@@ -26,10 +26,11 @@ import { useAuth0 } from '@auth0/auth0-vue';
 export default {
   name: "profile-view",
   setup() {
-    const auth0 = useAuth0();
+    const { user, getAccessTokenSilently } = useAuth0();
+    getAccessTokenSilently().then((token) => console.log(token));
     
     return {
-      user: auth0.user,
+      user,
     }
   }
 };


### PR DESCRIPTION
- Add audience in auth_config.json.example
- include audience in createAuth0() because it is required in access token v2
- In profile view, call getAccessTokenSilently() and console.log the result.  It is because developers may be curious of the payload of the access token and want to use jwt.io or other tools to decode the token.