### PR TITLE
Use structured entries for env snippet

### DIFF
--- a/quickstart/quickstart-login.yaml
+++ b/quickstart/quickstart-login.yaml
@@ -53,12 +53,19 @@ snippets:
     source: "quickstart/scripts/install-auth0.sh"
     language: "bash"
   env: &env
+    type: constructed
     fileName: *defaultEnvFileName
-    content: |
-      VITE_AUTH0_DOMAIN=%AUTH0_DOMAIN%
-      VITE_AUTH0_CLIENT_ID=%AUTH0_CLIENT_ID%
-      PORT=%PORT%
     language: "bash"
+    entries:
+      - type: var
+        name: VITE_AUTH0_DOMAIN
+        value: "%AUTH0_DOMAIN%"
+      - type: var
+        name: VITE_AUTH0_CLIENT_ID
+        value: "%AUTH0_CLIENT_ID%"
+      - type: var
+        name: PORT
+        value: "%PORT%"
   app-vue: &appVue
     source: "src/App.vue"
     language: "vue"

--- a/tools/__tests__/auth0-config.test.cjs
+++ b/tools/__tests__/auth0-config.test.cjs
@@ -399,4 +399,196 @@ ENABLE_FEATURE_X=true
       expect(content).not.toContain("VITE_AUTH0_CLIENT_ID=client with spaces");
     });
   });
+
+  describe("parseEnvLines", () => {
+    const { parseEnvLines } = require("../auth0-config.cjs");
+
+    test("should parse active KEY=VALUE lines", () => {
+      const result = parseEnvLines("FOO=bar");
+      expect(result).toEqual([
+        { type: "active", key: "FOO", value: "bar", trimmedValue: "bar", line: "FOO=bar" },
+      ]);
+    });
+
+    test("should preserve values containing '=' signs", () => {
+      const result = parseEnvLines("URL=https://example.com?a=1&b=2");
+      expect(result).toEqual([
+        {
+          type: "active",
+          key: "URL",
+          value: "https://example.com?a=1&b=2",
+          trimmedValue: "https://example.com?a=1&b=2",
+          line: "URL=https://example.com?a=1&b=2",
+        },
+      ]);
+    });
+
+    test("should classify comment lines", () => {
+      const result = parseEnvLines("# this is a comment");
+      expect(result).toEqual([
+        { type: "comment", line: "# this is a comment" },
+      ]);
+    });
+
+    test("should classify indented comment lines", () => {
+      const result = parseEnvLines("  # indented comment");
+      expect(result).toEqual([
+        { type: "comment", line: "  # indented comment" },
+      ]);
+    });
+
+    test("should classify empty lines", () => {
+      const result = parseEnvLines("");
+      expect(result).toEqual([{ type: "empty", line: "" }]);
+    });
+
+    test("should classify whitespace-only lines as empty", () => {
+      const result = parseEnvLines("   ");
+      expect(result).toEqual([{ type: "empty", line: "   " }]);
+    });
+
+    test("should classify lines with no '=' as empty", () => {
+      const result = parseEnvLines("JUST_A_KEY");
+      expect(result).toEqual([{ type: "empty", line: "JUST_A_KEY" }]);
+    });
+
+    test("should handle KEY= with empty value", () => {
+      const result = parseEnvLines("EMPTY=");
+      expect(result).toEqual([
+        { type: "active", key: "EMPTY", value: "", trimmedValue: "", line: "EMPTY=" },
+      ]);
+    });
+
+    test("should trim whitespace from keys", () => {
+      const result = parseEnvLines("  MY_KEY  =value");
+      expect(result[0].key).toBe("MY_KEY");
+    });
+
+    test("should preserve original line including whitespace", () => {
+      const result = parseEnvLines("  MY_KEY  =  value  ");
+      expect(result[0].line).toBe("  MY_KEY  =  value  ");
+    });
+
+    test("should trim trailing whitespace from value via line.trim()", () => {
+      const result = parseEnvLines("KEY=  spaced  ");
+      expect(result[0].value).toBe("  spaced");
+      expect(result[0].trimmedValue).toBe("spaced");
+    });
+
+    test("should parse multi-line content correctly", () => {
+      const content = [
+        "# Config",
+        "A=1",
+        "",
+        "B=2",
+      ].join("\n");
+      const result = parseEnvLines(content);
+      expect(result).toEqual([
+        { type: "comment", line: "# Config" },
+        { type: "active", key: "A", value: "1", trimmedValue: "1", line: "A=1" },
+        { type: "empty", line: "" },
+        { type: "active", key: "B", value: "2", trimmedValue: "2", line: "B=2" },
+      ]);
+    });
+
+    test("should treat a bare '=' as empty (no key)", () => {
+      const result = parseEnvLines("=value");
+      expect(result[0].type).toBe("empty");
+    });
+  });
+
+  describe("validateEnvConfig", () => {
+    const { validateEnvConfig } = require("../auth0-config.cjs");
+
+    const validConfig = {
+      fileName: ".env.local",
+      entries: [
+        { type: "var", name: "DOMAIN", value: "%AUTH0_DOMAIN%" },
+        { type: "var", name: "PORT", value: "%PORT%" },
+      ],
+    };
+
+    test("should return var entries for valid config", () => {
+      const result = validateEnvConfig(validConfig, "test.yaml");
+      expect(result).toEqual([
+        { type: "var", name: "DOMAIN", value: "%AUTH0_DOMAIN%" },
+        { type: "var", name: "PORT", value: "%PORT%" },
+      ]);
+    });
+
+    test("should reject missing envSnippet", () => {
+      expect(() => validateEnvConfig(null, "test.yaml")).toThrow(
+        "envSnippet property is missing",
+      );
+    });
+
+    test("should reject entries that is not an array", () => {
+      expect(() =>
+        validateEnvConfig(
+          { fileName: ".env.local", entries: "not-an-array" },
+          "test.yaml",
+        ),
+      ).toThrow("must have `entries` array");
+    });
+
+    test("should reject missing fileName", () => {
+      expect(() =>
+        validateEnvConfig({ entries: [{ type: "var", name: "X", value: "Y" }] }, "test.yaml"),
+      ).toThrow("must have `fileName` specified");
+    });
+
+    test("should reject entry with missing name", () => {
+      expect(() =>
+        validateEnvConfig(
+          { fileName: ".env.local", entries: [{ type: "var", value: "val" }] },
+          "test.yaml",
+        ),
+      ).toThrow("must have `name` and `value`");
+    });
+
+    test("should reject entry with null value (js-yaml parses missing fields as null)", () => {
+      expect(() =>
+        validateEnvConfig(
+          { fileName: ".env.local", entries: [{ type: "var", name: "X", value: null }] },
+          "test.yaml",
+        ),
+      ).toThrow("must have `name` and `value`");
+    });
+
+    test("should reject entry with undefined value", () => {
+      expect(() =>
+        validateEnvConfig(
+          { fileName: ".env.local", entries: [{ type: "var", name: "X" }] },
+          "test.yaml",
+        ),
+      ).toThrow("must have `name` and `value`");
+    });
+
+    test("should filter out non-var entries", () => {
+      const config = {
+        fileName: ".env.local",
+        entries: [
+          { type: "comment", text: "ignored" },
+          { type: "var", name: "KEEP", value: "yes" },
+        ],
+      };
+      const result = validateEnvConfig(config, "test.yaml");
+      expect(result).toEqual([{ type: "var", name: "KEEP", value: "yes" }]);
+    });
+
+    test("should accept numeric values without throwing", () => {
+      const config = {
+        fileName: ".env.local",
+        entries: [{ type: "var", name: "PORT", value: 3000 }],
+      };
+      const result = validateEnvConfig(config, "test.yaml");
+      expect(result).toEqual([{ type: "var", name: "PORT", value: 3000 }]);
+    });
+
+    test("should accept empty entries array", () => {
+      const config = { fileName: ".env.local", entries: [] };
+      const result = validateEnvConfig(config, "test.yaml");
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/tools/auth0-config.cjs
+++ b/tools/auth0-config.cjs
@@ -32,86 +32,98 @@ function parseEnvLines(content) {
   });
 }
 
-try {
-  const args = parseArgs(process.argv);
-
-  // Validate required arguments
-  if (!args.domain) {
-    console.error("Error: --domain argument is required");
-    console.error(
-      "Usage: node auth0-config.cjs --domain <domain> --clientId <clientId> [--port <port>]",
-    );
-    process.exit(1);
-  }
-
-  if (!args.clientId) {
-    console.error("Error: --clientId argument is required");
-    console.error(
-      "Usage: node auth0-config.cjs --domain <domain> --clientId <clientId> [--port <port>]",
-    );
-    process.exit(1);
-  }
-
-  // Validate port argument if provided
-  if (args.port) {
-    const portNumber = parseInt(args.port, 10);
-    if (isNaN(portNumber) || portNumber.toString() !== args.port.toString()) {
-      console.error("Error: --port argument must be a valid number");
-      console.error(
-        "Usage: node auth0-config.cjs --domain <domain> --clientId <clientId> [--port <port>]",
-      );
-      process.exit(1);
-    }
-  }
-
-  // TODO: make this a param or config
-  const yamlPath = path.join(
-    __dirname,
-    "../quickstart",
-    "quickstart-login.yaml",
-  );
-  const quickstartConfig = yaml.load(fs.readFileSync(yamlPath, "utf8"));
-
-  // Get env snippet from the referenced alias
-  const envConfig = quickstartConfig.envSnippet;
+function validateEnvConfig(envConfig, yamlPath) {
   if (!envConfig)
     throw new Error(`The envSnippet property is missing in ${yamlPath}`);
-  if (!envConfig.content)
+  if (!Array.isArray(envConfig.entries))
     throw new Error(
-      `The envSnippet property must have \`content\` hardcoded in ${yamlPath}`,
+      `The envSnippet property must have \`entries\` array in ${yamlPath}`,
     );
   if (!envConfig.fileName)
     throw new Error(
       `The envSnippet property must have \`fileName\` specified in ${yamlPath}`,
     );
 
-  const envPath = path.join(__dirname, "..", envConfig.fileName);
-  const replacements = {
-    auth0Domain: args.domain,
-    auth0ClientId: args.clientId,
-    port: args.port || quickstartConfig.inputs.port.default,
-  };
-
-  // Read and parse existing file
-  let existingLines = [];
-  try {
-    existingLines = parseEnvLines(fs.readFileSync(envPath, "utf8"));
-  } catch (err) {
-    // File doesn't exist
+  const varEntries = envConfig.entries.filter((e) => e.type === "var");
+  for (const entry of varEntries) {
+    if (!entry.name || entry.value == null)
+      throw new Error(
+        `Each var entry in envSnippet.entries must have \`name\` and \`value\` in ${yamlPath}`,
+      );
   }
 
-  // Parse env snippet content
-  const targetLines = parseEnvLines(envConfig.content);
-  const managedKeys = new Set(
-    targetLines.filter((l) => l.type === "active").map((l) => l.key),
-  );
+  return varEntries;
+}
 
-  // Calculate target values with placeholders replaced
-  const targetValues = Object.fromEntries(
-    targetLines
-      .filter((l) => l.type === "active")
-      .map((line) => [
-        line.key.trim(),
+if (require.main === module) {
+  try {
+    const args = parseArgs(process.argv);
+
+    // Validate required arguments
+    if (!args.domain) {
+      console.error("Error: --domain argument is required");
+      console.error(
+        "Usage: node auth0-config.cjs --domain <domain> --clientId <clientId> [--port <port>]",
+      );
+      process.exit(1);
+    }
+
+    if (!args.clientId) {
+      console.error("Error: --clientId argument is required");
+      console.error(
+        "Usage: node auth0-config.cjs --domain <domain> --clientId <clientId> [--port <port>]",
+      );
+      process.exit(1);
+    }
+
+    // Validate port argument if provided
+    if (args.port) {
+      const portNumber = parseInt(args.port, 10);
+      if (
+        isNaN(portNumber) ||
+        portNumber.toString() !== args.port.toString()
+      ) {
+        console.error("Error: --port argument must be a valid number");
+        console.error(
+          "Usage: node auth0-config.cjs --domain <domain> --clientId <clientId> [--port <port>]",
+        );
+        process.exit(1);
+      }
+    }
+
+    // TODO: make this a param or config
+    const yamlPath = path.join(
+      __dirname,
+      "../quickstart",
+      "quickstart-login.yaml",
+    );
+    const quickstartConfig = yaml.load(fs.readFileSync(yamlPath, "utf8"));
+
+    // Get env snippet from the referenced alias
+    const envConfig = quickstartConfig.envSnippet;
+    const varEntries = validateEnvConfig(envConfig, yamlPath);
+
+    const envPath = path.join(__dirname, "..", envConfig.fileName);
+    const replacements = {
+      auth0Domain: args.domain,
+      auth0ClientId: args.clientId,
+      port: args.port || quickstartConfig.inputs.port.default,
+    };
+
+    // Read and parse existing file
+    let existingLines = [];
+    try {
+      existingLines = parseEnvLines(fs.readFileSync(envPath, "utf8"));
+    } catch (err) {
+      // File doesn't exist
+    }
+
+    const managedKeys = new Set(varEntries.map((e) => e.name));
+
+    // Calculate target values with placeholders replaced
+    const targetValues = Object.fromEntries(
+      varEntries.map((entry) => [
+        entry.name,
         Object.entries(quickstartConfig.placeholders || {})
           .reduce((value, [placeholder, config]) => {
             const replacementValue = config?.inputKey
@@ -124,78 +136,83 @@ try {
               new RegExp(placeholder, "g"),
               replacementValue,
             );
-          }, line.value)
+          }, String(entry.value))
           .trim(),
       ]),
-  );
-
-  // Get last active value for each managed key
-  const activeValues = Object.fromEntries(
-    [...existingLines]
-      .reverse()
-      .filter((l) => l.type === "active" && managedKeys.has(l.key))
-      .filter((line, i, arr) => arr.findIndex((l) => l.key === line.key) === i)
-      .map((l) => [l.key, l.trimmedValue]),
-  );
-
-  // Track status of all managed variables
-  const variableStatus = Object.entries(targetValues).map(([key, value]) => {
-    if (!activeValues[key]) {
-      return { key, status: "added", changed: true };
-    }
-    const changed = activeValues[key] !== value.trim();
-    return {
-      key,
-      status: changed ? "updated" : "unchanged",
-      changed,
-    };
-  });
-
-  const hasChanges = variableStatus.some((item) => item.changed);
-
-  // Only update file when changes are needed
-  if (hasChanges) {
-    // Comment all existing managed keys and append all values
-    const outputLines = [
-      ...existingLines.map((line) =>
-        line.type === "active" && managedKeys.has(line.key)
-          ? { ...line, type: "comment", line: `# ${line.line}` }
-          : line,
-      ),
-      { type: "empty", line: "" },
-      {
-        type: "comment",
-        line: `# added by auth0-config at ${new Date().toISOString()}`,
-      },
-      ...Object.entries(targetValues).map(([key, value]) => ({
-        type: "active",
-        key,
-        value,
-        line: `${key}=${value}`,
-      })),
-    ];
-
-    const finalContent = outputLines.map((l) => l.line).join("\n") + "\n";
-    fs.writeFileSync(envPath, finalContent);
-    console.log(
-      `Auth0 configuration has been written to: ${envConfig.fileName}`,
     );
-  } else {
-    console.log(`No changes needed, file ${envConfig.fileName} unchanged`);
-  }
 
-  // Always show status for all variables
-  console.log("Config keys state:");
-  variableStatus.forEach(({ key, status }) => {
-    const message =
-      status === "added"
-        ? "adding new value"
-        : status === "updated"
-          ? "commenting previous value and adding new"
-          : "already up to date";
-    console.log(`  ${key}: ${message}`);
-  });
-} catch (e) {
-  console.error("Error:", e.message);
-  process.exit(1);
+    // Get last active value for each managed key
+    const activeValues = Object.fromEntries(
+      [...existingLines]
+        .reverse()
+        .filter((l) => l.type === "active" && managedKeys.has(l.key))
+        .filter(
+          (line, i, arr) => arr.findIndex((l) => l.key === line.key) === i,
+        )
+        .map((l) => [l.key, l.trimmedValue]),
+    );
+
+    // Track status of all managed variables
+    const variableStatus = Object.entries(targetValues).map(([key, value]) => {
+      if (!activeValues[key]) {
+        return { key, status: "added", changed: true };
+      }
+      const changed = activeValues[key] !== value.trim();
+      return {
+        key,
+        status: changed ? "updated" : "unchanged",
+        changed,
+      };
+    });
+
+    const hasChanges = variableStatus.some((item) => item.changed);
+
+    // Only update file when changes are needed
+    if (hasChanges) {
+      // Comment all existing managed keys and append all values
+      const outputLines = [
+        ...existingLines.map((line) =>
+          line.type === "active" && managedKeys.has(line.key)
+            ? { ...line, type: "comment", line: `# ${line.line}` }
+            : line,
+        ),
+        { type: "empty", line: "" },
+        {
+          type: "comment",
+          line: `# added by auth0-config at ${new Date().toISOString()}`,
+        },
+        ...Object.entries(targetValues).map(([key, value]) => ({
+          type: "active",
+          key,
+          value,
+          line: `${key}=${value}`,
+        })),
+      ];
+
+      const finalContent = outputLines.map((l) => l.line).join("\n") + "\n";
+      fs.writeFileSync(envPath, finalContent);
+      console.log(
+        `Auth0 configuration has been written to: ${envConfig.fileName}`,
+      );
+    } else {
+      console.log(`No changes needed, file ${envConfig.fileName} unchanged`);
+    }
+
+    // Always show status for all variables
+    console.log("Config keys state:");
+    variableStatus.forEach(({ key, status }) => {
+      const message =
+        status === "added"
+          ? "adding new value"
+          : status === "updated"
+            ? "commenting previous value and adding new"
+            : "already up to date";
+      console.log(`  ${key}: ${message}`);
+    });
+  } catch (e) {
+    console.error("Error:", e.message);
+    process.exit(1);
+  }
 }
+
+module.exports = { validateEnvConfig, parseEnvLines };


### PR DESCRIPTION
## Summary
- Replace freeform `content` string with structured `entries` array in the env snippet of `quickstart-login.yaml`
- Update `auth0-config.cjs` to consume the new format with robust validation (`Array.isArray`, entry shape checks, `String()` coercion for numeric values)
- Extract `validateEnvConfig` and `parseEnvLines` as exported functions behind a `require.main` guard for testability
- Add 22 unit tests covering all `validateEnvConfig` branches (missing entries, null/undefined values, non-array entries, numeric coercion, non-var filtering) and `parseEnvLines` edge cases (values with `=`, comments, empty lines, whitespace trimming, bare `=`)

## Test plan
- [x] All 42 tests pass (19 existing integration + 13 new `parseEnvLines` unit + 10 new `validateEnvConfig` unit)
- [ ] Confirm `tools/check-port.cjs` still works (only reads `fileName`, which is unchanged)
- [ ] Run `node tools/auth0-config.cjs --domain <domain> --clientId <id>` end-to-end and verify `.env.local` output
- [ ] Verify the dashboard snippet renderer supports the `entries` format (the `content` property was removed)